### PR TITLE
fix: RuntimeError: dictionary changed size during iteration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools networkx nose numpy flake8
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools networkx nose numpy flake8 cython
   - source activate test-environment
-  - pip install coverage==3.7.1
+  - pip install coverage
   - python setup.py install
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,17 @@
 FROM ubuntu:14.04
 MAINTAINER Amy Krause <a.krause@epcc.ed.ac.uk>
 
-RUN apt-get update && apt-get install wget curl python-dev python-pip python-setuptools git openmpi-bin openmpi-common libopenmpi-dev -y
+RUN apt-get update && apt-get install -y  \
+    wget \
+    curl \
+    python-dev \
+    python-pip \
+    python-setuptools \
+    git \
+    openmpi-bin \
+    openmpi-common \
+    libopenmpi-dev
+
 RUN pip install mpi4py
 
 # install dispel4py latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Create Ubuntu environment
 
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 MAINTAINER Amy Krause <a.krause@epcc.ed.ac.uk>
 
 RUN apt-get update && apt-get install -y  \
@@ -17,5 +17,5 @@ RUN apt-get update && apt-get install -y  \
 RUN pip install mpi4py
 
 # install dispel4py latest
-RUN pip install git+git://github.com/dispel4py/dispel4py.git@master
+RUN pip install git+git://github.com/sirspock/dispel4py.git@master
 

--- a/dispel4py/new/processor.py
+++ b/dispel4py/new/processor.py
@@ -354,7 +354,7 @@ def create_partitioned(workflow_all):
         component_ids = [pe.id for pe in part]
         workflow = copy.deepcopy(workflow_all)
         graph = workflow.graph
-        for node in graph.nodes():
+        for node in list(graph.nodes()):
             if node.getContainedObject().id not in component_ids:
                 graph.remove_node(node)
         processes, inputmappings, outputmappings = \

--- a/dispel4py/test/multi_process_test.py
+++ b/dispel4py/test/multi_process_test.py
@@ -214,7 +214,7 @@ def coverage_multiprocessing_process():    # pragma: no cover
         return
 
     from coverage.collector import Collector
-    from coverage.control import coverage
+    from coverage import coverage
     # detect if coverage was running in forked process
     if Collector._collectors:
         original = multiprocessing.Process._bootstrap

--- a/dispel4py/workflow_graph.py
+++ b/dispel4py/workflow_graph.py
@@ -134,7 +134,7 @@ class WorkflowGraph(object):
                                        (fromConnection, toConnection)]})
 
     def getContainedObjects(self):
-        nodes = [node.getContainedObject() for node in self.graph.nodes()]
+        nodes = [node.getContainedObject() for node in list(self.graph.nodes())]
         return sorted(nodes, key=lambda x: x.id)
 
     def propagate_types(self):
@@ -144,7 +144,7 @@ class WorkflowGraph(object):
         connected consumers.
         '''
         visited = set()
-        for node in self.graph.nodes():
+        for node in list(self.graph.nodes()):
             if node not in visited:
                 self.__assign_types(node, visited)
 
@@ -176,7 +176,7 @@ class WorkflowGraph(object):
         while hasComposites:
             hasComposites = False
             toRemove = set()
-            for node in self.graph.nodes():
+            for node in list(self.graph.nodes()):
                 if node.nodeType == WorkflowNode.WORKFLOW_NODE_CP:
                     hasComposites = True
                     toRemove.add(node)


### PR DESCRIPTION
create_partitioned remove a node using dictionary. That isn't allowed. https://cito.github.io/blog/never-iterate-a-changing-dict/ 
```
dispel4py multi int_ext_graph.py -d '{"read" : [ {"input" : "coordinates.txt"} ]}' -n 4 -s

Traceback (most recent call last):
  File "/root/.v/bin/dispel4py", line 11, in <module>
    sys.exit(main())
  File "/root/.v/lib/python2.7/site-packages/dispel4py/new/processor.py", line 779, in main
    error_message = process(graph, inputs=inputs, args=args)
  File "/root/.v/lib/python2.7/site-packages/dispel4py/new/multi_process.py", line 86, in process
    ubergraph = processor.create_partitioned(workflow)
  File "/root/.v/lib/python2.7/site-packages/dispel4py/new/processor.py", line 357, in create_partitioned
    for node in graph.nodes():
RuntimeError: dictionary changed size during iteration
````